### PR TITLE
Fix alloc-dealloc-mismatch

### DIFF
--- a/emmy_core/transporter.cpp
+++ b/emmy_core/transporter.cpp
@@ -152,7 +152,7 @@ typedef struct {
 static void after_write(uv_write_t* req, int status) {
 	const auto writeReq = reinterpret_cast<write_req_t*>(req);
 	free(writeReq->buf.base);
-	free(writeReq);
+	delete writeReq;
 }
 
 void Transporter::Send(uv_stream_t* handler, int cmd, const char* data, size_t len) {


### PR DESCRIPTION
This was reported by address sanitizer while the Lua debugger was
attached to an ASAN enabled binary. This fixes that error.