### PR TITLE
fix Debugger::GetVariable may be Infinite loop!

### DIFF
--- a/emmy_core/emmy_core.h
+++ b/emmy_core/emmy_core.h
@@ -23,6 +23,10 @@
 #define EMMY_CORE_EXPORT    extern
 #endif
 
+#ifndef EMMY_CORE_GETVARIABLE_LIMIT
+#define EMMY_CORE_GETVARIABLE_LIMIT 188
+#endif
+
 #include "api/lua_api.h"
 
 // lua version

--- a/emmy_core/emmy_debugger.h
+++ b/emmy_core/emmy_debugger.h
@@ -84,7 +84,7 @@ public:
 	void AsyncDoString(const char* code);
 	bool Eval(EvalContext* evalContext, bool force = false);
 	bool GetStacks(lua_State* L, std::vector<Stack*>& stacks, StackAllocatorCB alloc);
-	void GetVariable(Variable* variable, lua_State* L, int index, int depth, bool queryHelper = true);
+	void GetVariable(Variable* variable, lua_State* L, int index, int depth, bool queryHelper = true, int32_t* loopCount = nullptr);
 	void DoAction(DebugAction action);
 	void EnterDebugMode(lua_State* L);
 	void ExitDebugMode();


### PR DESCRIPTION
在macOS调试 UE4.26.1 + UnLua 一断点UE4Editor就crash，官方的https://github.com/Tencent/UnLua 就可以重现。

原因：
 发现 **Debugger::GetVariable** 无限循环递归堆栈溢出导致的crash

修复方案：限制递归次数
```c++
#ifndef EMMY_CORE_GETVARIABLE_LIMIT
#define EMMY_CORE_GETVARIABLE_LIMIT 188
#endif
```

Windows下没问题，若是其他第三方的实现也有类似错误至少不会无法调试，不是个完美的方案。