### PR TITLE
Extend queryHelper condition to include LUA_TSTRING

### DIFF
--- a/emmy_debugger/src/debugger/emmy_debugger.cpp
+++ b/emmy_debugger/src/debugger/emmy_debugger.cpp
@@ -371,7 +371,7 @@ void Debugger::GetVariable(lua_State *L, Idx<Variable> variable, int index, int 
 	variable->valueType = type;
 
 
-	if (queryHelper && (type == LUA_TTABLE || type == LUA_TUSERDATA || type == LUA_TFUNCTION)) {
+	if (queryHelper && (type == LUA_TTABLE || type == LUA_TUSERDATA || type == LUA_TFUNCTION || type == LUA_TSTRING)) {
 		if (manager->extension.QueryVariable(L, variable, typeName, index, depth)) {
 			return;
 		}


### PR DESCRIPTION
用于自定义对string的显示处理，以便增强字符串信息的可视化。
需要配合IntelliJ-EmmyLua的PR使用，详见：[https://github.com/EmmyLua/IntelliJ-EmmyLua/pull/573](https://github.com/EmmyLua/IntelliJ-EmmyLua/pull/573)。