### PR TITLE
修复特定情况下查看函数时可能导致报错

### DIFF
--- a/emmy_debugger/src/debugger/emmy_debugger.cpp
+++ b/emmy_debugger/src/debugger/emmy_debugger.cpp
@@ -333,18 +333,19 @@ void DisplayFunction(Idx<Variable> variable, lua_State *L, int index) {
 	lua_pushvalue(L, index);
 	if (lua_getinfo(L, ">Snu", &ar) == 0) {
 		variable->value = ToPointer(L, index);
-		return;
 	}
-	switch (luaVersion) {
-		case LuaVersion::LUA_54: {
-			DisplayFunction54(variable, L, index, ar.u.ar54);
-			break;
+	else {
+		switch (luaVersion) {
+			case LuaVersion::LUA_54: {
+				DisplayFunction54(variable, L, index, ar.u.ar54);
+				break;
+			}
+			default: {
+				variable->value = ToPointer(L, index);
+				break;
+			}
 		}
-		default: {
-			variable->value = ToPointer(L, index);
-			break;
-		}
-	}
+    }
 	lua_settop(L, index);
 }
 #endif


### PR DESCRIPTION
某些特殊情况下如果DisplayFunction时lua_getinfo(L, ">Snu", &ar) == 0会直接返回，导致栈状态不对。