### PR TITLE
修复了eval expr返回错误时导致的栈异常

### DIFF
--- a/emmy_debugger/src/debugger/emmy_debugger.cpp
+++ b/emmy_debugger/src/debugger/emmy_debugger.cpp
@@ -972,6 +972,7 @@ bool Debugger::DoEval(std::shared_ptr<EvalContext> evalContext) {
 		evalContext->error = lua_tostring(L, -1);
 	}
 
+	lua_pop(L, 1);
 	return false;
 }
 


### PR DESCRIPTION
DoEval中计算表达式异常时没有把错误信息出栈，导致栈可能一直往上涨