### PR TITLE
StepIn，相同文件行有概率导致程序崩溃

### DIFF
--- a/emmy_debugger/src/debugger/hook_state.cpp
+++ b/emmy_debugger/src/debugger/hook_state.cpp
@@ -98,6 +98,7 @@ void HookStateStepIn::ProcessHook(std::shared_ptr<Debugger> debugger, lua_State*
 	UpdateStackLevel(debugger, L, ar);
 	if (getDebugEvent(ar) == LUA_HOOKLINE)
 	{
+		lua_getinfo(L, "nSl", ar);
 		auto currentLine = getDebugCurrentLine(ar);
 		auto source = getDebugSource(ar);
 		if(currentLine != line || file != source)


### PR DESCRIPTION
F11步进未获取调试信息，导致条件判断走到file != source时，程序有概率因source的内存问题而崩溃，添加调试信息后解决。