### PR TITLE
Fix spurious continue in the debug mode

### DIFF
--- a/emmy_debugger/src/debugger/emmy_debugger.cpp
+++ b/emmy_debugger/src/debugger/emmy_debugger.cpp
@@ -660,7 +660,7 @@ void Debugger::EnterDebugMode() {
 		std::unique_lock<std::mutex> lockEval(evalMtx);
 		if (evalQueue.empty() && blocking) {
 			lockEval.unlock();
-			cvRun.wait(lock);
+			cvRun.wait(lock, [this] { return !blocking || !evalQueue.empty(); });
 			lockEval.lock();
 		}
 		if (!evalQueue.empty()) {


### PR DESCRIPTION
This patch fixes the problem I came across when tried to use the
debugger on MacOS with arm64. When Lua hit breakpoint it captured it
though the program execution did not stop since the debug loop exited
almost instantly.

Debug prints showed that this happened due to the spurious wake ups of
the conditional variable `cvRun`. None of the methods notified this
conditional so it seems it is a spurious wake up. Probably it is
specific to the architecture.

This small patch fixes this by adding a predicate to the conditional
variable. It waits until the debugging is finished or there are
evals to run.
