### PR TITLE
TcpSharedListen多线程监听支持

### DIFF
--- a/emmy_debugger/src/emmy_facade.cpp
+++ b/emmy_debugger/src/emmy_facade.cpp
@@ -114,6 +114,10 @@ bool EmmyFacade::TcpSharedListen(lua_State *L, const std::string &host, int port
 	if (transporter == nullptr) {
 		return TcpListen(L, host, port, err);
 	}
+	if (_emmyDebuggerManager.GetDebugger(L) == nullptr) {
+		_emmyDebuggerManager.AddDebugger(L);
+		SetReadyHook(L);
+	}
 	return true;
 }
 

--- a/emmy_debugger/src/transporter/transporter.cpp
+++ b/emmy_debugger/src/transporter/transporter.cpp
@@ -86,7 +86,7 @@ void Transporter::Receive(const char* data, size_t len)
 		size_t start = pos;
 		for (size_t i = pos; i < receiveSize; i++)
 		{
-			if (data[i] == '\n')
+			if (buf[i] == '\n')
 			{
 				pos = i + 1;
 				break;


### PR DESCRIPTION
修复tcpSharedListen 只有第一个调用的线程会执行TcpListen，后续线程直接返回。单进程多线程的环境下，只有第一个线程能正常断点。