### PR TITLE
fix: fix pause not breaking after attach without prior breakpoint 

### DIFF
--- a/emmy_debugger/src/emmy_facade.cpp
+++ b/emmy_debugger/src/emmy_facade.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Copyright (c) 2019. tangzx(love.tangzx@qq.com)
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -334,6 +334,10 @@ void EmmyFacade::Hook(lua_State *L, lua_Debug *ar) {
 			return;
 		}
 
+		// 没人断着时，把当前活跃 vm 记下来，使未断点过的 pause 能定位到目标
+		if (!_emmyDebuggerManager.GetHitBreakpoint()) {
+			_emmyDebuggerManager.SetHitDebugger(debugger);
+		}
 		debugger->Hook(ar, L);
 	} else {
 		if (workMode == WorkMode::Attach) {
@@ -349,6 +353,9 @@ void EmmyFacade::Hook(lua_State *L, lua_Debug *ar) {
 
 			this->transporter->Send(int(MessageCMD::AttachedNotify), obj);
 
+			if (!_emmyDebuggerManager.GetHitBreakpoint()) {
+				_emmyDebuggerManager.SetHitDebugger(debugger);
+			}
 			debugger->Hook(ar, L);
 		}
 	}


### PR DESCRIPTION
## 背景
lua 里有个死循环，想 attach 之后点击 pause 看看堆栈，发现断不下来

## 问题

attach 之后，如果还没有任何断点被触发过，此时点击 IDE 的 pause 按钮无效，调试器不会停下来。必须先命中过一次断点，pause 才能正常工作。

## 根因

IDE 的 pause 命令在 `EmmyDebuggerManager::DoAction` 里只对 `hitDebugger` 生效，而 `hitDebugger` 只在断点真正命中后才被赋值。所以 attach 后未断点过时 `hitDebugger == nullptr`，`DoAction(Break)` 直接静默 return，`HookStateBreak` 装不上去。

## 修复

在 `EmmyFacade::Hook` 进入 lua 处理路径时，若当前没有 hit 的 debugger，就把正在跑 hook 的这个 debugger 登记为 `hitDebugger`。这样首次 pause 也能定位到目标 vm。仅修改 `emmy_facade.cpp`，新增 7 行。
